### PR TITLE
Open areas movement fix

### DIFF
--- a/lib/db/src/saves.rs
+++ b/lib/db/src/saves.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 #[derive(Serialize, Deserialize)]
 pub struct PlayerRecord {
     pub char_bag: CharBag,
-    pub world: WorldState,
+    pub world:    WorldState,
 }
 
 pub struct PlayerDb {
@@ -30,8 +30,8 @@ impl PlayerDb {
         if !path.exists() {
             return Ok(None);
         }
-        let bytes =
-            fs::read(&path).with_context(|| format!("failed to read save: {}", path.display()))?;
+        let bytes = fs::read(&path)
+            .with_context(|| format!("failed to read save: {}", path.display()))?;
         let record = bincode::deserialize(&bytes)
             .with_context(|| format!("failed to deserialize save for {uid}"))?;
         Ok(Some(record))
@@ -41,15 +41,16 @@ impl PlayerDb {
     pub async fn save(&self, uid: &str, char_bag: &CharBag, world: &WorldState) -> Result<()> {
         let bytes = bincode::serialize(&PlayerRecord {
             char_bag: char_bag.clone(),
-            world: world.clone(),
+            world:    world.clone(),
         })
         .context("failed to serialize save")?;
 
         let path = self.path(uid);
-        let tmp = path.with_extension("bin.tmp");
+        let tmp  = path.with_extension("bin.tmp");
         fs::write(&tmp, &bytes)
             .with_context(|| format!("failed to write tmp: {}", tmp.display()))?;
-        fs::rename(&tmp, &path).with_context(|| format!("failed to rename: {}", path.display()))?;
+        fs::rename(&tmp, &path)
+            .with_context(|| format!("failed to rename: {}", path.display()))?;
         Ok(())
     }
 

--- a/lib/logic/src/enums.rs
+++ b/lib/logic/src/enums.rs
@@ -97,7 +97,6 @@ impl UnlockSystemType {
 
     pub fn all() -> Vec<i32> {
         vec![
-            Self::Map as i32,
             Self::Inventory as i32,
             Self::Watch as i32,
             Self::ValuableDepot as i32,

--- a/lib/logic/src/player.rs
+++ b/lib/logic/src/player.rs
@@ -18,12 +18,12 @@ impl Default for WorldState {
         Self {
             role_level: 1,
             role_exp: 0,
-            last_scene: "map01_dg003".to_string(),
-            pos_x: 825.11,
-            pos_y: 14.6,
-            pos_z: 421.61,
+            last_scene: "map01_lv001".to_string(),
+            pos_x: 469.0,
+            pos_y: 107.11,
+            pos_z: 217.83,
             rot_x: 0.0,
-            rot_y: -101.14,
+            rot_y: 60.00,
             rot_z: 0.0,
         }
     }


### PR DESCRIPTION
(Workaround) Removes the map unlock so that movement doesn't break in open areas 
+change the default area to lv001 (The Hub)